### PR TITLE
fix: display error in parsing '<, >' into html tags in the output results window

### DIFF
--- a/www/src/Playground.ts
+++ b/www/src/Playground.ts
@@ -253,7 +253,7 @@ export class Playground {
     }
 
     public writeToTerminal(text: string): void {
-        this.editor.terminal.write(text)
+        this.editor.terminal.write(text.replace("<", "&lt;").replace(">", "&gt;"))
     }
 
     private markCodeAsUnsaved() {


### PR DESCRIPTION
<img width="327" alt="image" src="https://github.com/vlang/playground/assets/27794478/90102237-6f36-49ac-b5e5-b31e5cccd292">

1. Currently, `<, >` in the output window will be incorrectly parsed as `html tags`, which will not display the running results correctly. This PR handles `<, >` to avoid incorrect parsing.
2. For the latest version of v compiler, code compilation errors and warning messages are eliminated.
3. After this PR is merged, solve one more problem related to Closure IIFE: https://github.com/vlang/v/issues/20306


After fixed:
<img width="320" alt="image" src="https://github.com/vlang/playground/assets/27794478/6e883bc6-eb11-4e13-9906-38aed28504e9">
